### PR TITLE
Do not extract license params past end of terms and conditions

### DIFF
--- a/app/utils/GitHub.scala
+++ b/app/utils/GitHub.scala
@@ -159,8 +159,10 @@ class GitHub(configuration: Configuration, ws: WSClient, futures: Futures)(impli
   def licenseParams(key: String, accessToken: String): Future[Set[String]] = {
     license(key, accessToken).map { licenseInfo =>
       val body = (licenseInfo \ "body").as[String]
+      val end = body.indexOf("END OF TERMS AND CONDITIONS")
+      val trimmed = if (end > 0) body.substring(0, end) else body
       val paramMatcher = "(?<=\\[).+?(?=\\])".r
-      paramMatcher.findAllIn(body).toSet
+      paramMatcher.findAllIn(trimmed).toSet
     }
   }
 

--- a/test/utils/GitHubSpec.scala
+++ b/test/utils/GitHubSpec.scala
@@ -120,6 +120,10 @@ class GitHubSpec extends PlaySpec with BeforeAndAfterAll {
       val params = await(gitHub.licenseParams("mit", gitHubTestToken))
       params must equal (Set("year", "fullname"))
     }
+    "work with apache-2.0" in {
+      val params = await(gitHub.licenseParams("apache-2.0", gitHubTestToken))
+      params must equal (Set())
+    }
   }
 
   "GitHub.repoBranches" should {


### PR DESCRIPTION
Avoids filling in copyright holder info in Apache-2.0 and ECL-2.0 appendices.